### PR TITLE
Actualizo la url del repo maven de uqbar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,15 +6,15 @@
 
 	<repositories>
 		<repository>
-			<id>uqbar-wiki.org-releases</id>
-			<name>uqbar-wiki.org-releases</name>
-			<url>http://uqbar-wiki.org/mvn/releases</url>
+			<id>maven.uqbar.org-releases</id>
+			<name>maven.uqbar.org-releases</name>
+			<url>http://maven.uqbar.org/releases</url>
 		</repository>
 		<repository>
 			<snapshots />
-			<id>uqbar-wiki.org-snapshots</id>
-			<name>uqbar-wiki.org-snapshots</name>
-			<url>http://uqbar-wiki.org/mvn/snapshots</url>
+			<id>maven.uqbar.org-snapshots</id>
+			<name>maven.uqbar.org-snapshots</name>
+			<url>http://maven.uqbar.org/snapshots</url>
 		</repository>
 	</repositories>
 	


### PR DESCRIPTION
@fdodino Acabo de actualizar estos dos ejemplos con la URL nueva del repo maven de uqbar, no sé si se tendra que cambiar en otros proyectos.

No sé si esta es la mejor solución, capaz la dependencia que se esta usando y bajando de http://maven.uqbar.org/releases, debería bajarla de el m2 global.
